### PR TITLE
feat: txs all

### DIFF
--- a/common/sdk/src/clients/rpc-client/client.ts
+++ b/common/sdk/src/clients/rpc-client/client.ts
@@ -1,8 +1,10 @@
 import { StdSignature } from "@cosmjs/amino";
+import { StdFee } from "@cosmjs/amino/build/signdoc";
 import { AccountData, OfflineAminoSigner } from "@cosmjs/amino/build/signer";
 import { SigningStargateClient } from "@cosmjs/stargate";
 import { makeADR36AminoSignDoc } from "@keplr-wallet/cosmos";
 
+import { signTx, TxPromise } from "../../utils/helper";
 import KyveBaseMethods from "./kyve/base/v1beta1/base";
 import KyveBundlesMethods from "./kyve/bundles/v1beta1/bundles";
 import KyveDelegationMethods from "./kyve/delegation/v1beta1/delegation";
@@ -73,5 +75,18 @@ export default class KyveClient {
       signDoc
     );
     return signature;
+  }
+  async txsAll(
+    txs: TxPromise[],
+    options?: {
+      fee?: StdFee | "auto" | number;
+      memo?: string;
+    }
+  ) {
+    const txMessages = txs.map((tx) => tx.tx).flat();
+    return new TxPromise(
+      this.nativeClient,
+      await signTx(this.nativeClient, this.account.address, txMessages, options)
+    );
   }
 }

--- a/common/sdk/tsconfig.json
+++ b/common/sdk/tsconfig.json
@@ -1,10 +1,15 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "lib": [
+      "dom",
+      "esNext"
+    ],
     "declaration": true,
     "esModuleInterop": true,
     "outDir": "dist",
-    "strict": true
+    "strict": true,
+    "moduleResolution": "node"
   },
   "include": ["src/types/"],
   "files": ["src/index.ts"]

--- a/integrations/bitcoin/src/runtime.ts
+++ b/integrations/bitcoin/src/runtime.ts
@@ -1,4 +1,4 @@
-import { DataItem, IRuntime, Validator, sha256 } from "@kyvejs/protocol";
+import { DataItem, IRuntime, sha256, Validator } from "@kyvejs/protocol";
 
 import { name, version } from "../package.json";
 import { fetchBlock, fetchBlockHash } from "./utils";

--- a/integrations/celo/src/runtime.ts
+++ b/integrations/celo/src/runtime.ts
@@ -1,5 +1,5 @@
 import { StaticCeloProvider } from '@celo-tools/celo-ethers-wrapper';
-import { DataItem, IRuntime, Validator, sha256 } from '@kyvejs/protocol';
+import { DataItem, IRuntime, sha256, Validator } from '@kyvejs/protocol';
 import { providers } from 'ethers';
 
 import { name, version } from '../package.json';

--- a/integrations/evm/src/runtime.ts
+++ b/integrations/evm/src/runtime.ts
@@ -1,4 +1,4 @@
-import { DataItem, IRuntime, Validator, sha256 } from '@kyvejs/protocol';
+import { DataItem, IRuntime, sha256, Validator } from '@kyvejs/protocol';
 import { providers } from 'ethers';
 
 import { name, version } from '../package.json';

--- a/integrations/uniswap/src/evm-contract-events.ts
+++ b/integrations/uniswap/src/evm-contract-events.ts
@@ -1,4 +1,4 @@
-import { DataItem, IRuntime, Validator, sha256 } from '@kyvejs/protocol';
+import { DataItem, IRuntime, sha256, Validator } from '@kyvejs/protocol';
 import { providers, utils } from 'ethers';
 
 // Method to get the named args


### PR DESCRIPTION
Implemented a feature to send multiple messages in one transaction. Any method from SDK can be combined if it will return TxPromise 
example: 
```
//init
const sdkInstance = await sdk.fromMnemonic(mnemonic);
    const multiTransferTxPromise = await sdkInstance.kyve.base.v1beta1.multiTransfer([
        'kyve1qcual...',
        'kyve1pfs...'
    ], '1000000000');
    const transferTxPromise = await sdkInstance.kyve.base.v1beta1.transfer('kyve1qcua....', '1000000000');
    // combine several messages to one
    const txsAllResultPromise = await sdkInstance.txsAll([multiTransferTxPromise, transferTxPromise]);
    console.log(txsAllResult.txHash);
    console.log(txsAllResult.tx);
    // execute multiple messages 
    const txResult = await txsAllResultPromise.execute();
    console.log(txResult);
    // Also, we can combine messages from the regular methods and txsAll 
    const txsAllResult2 = await sdkInstance.txsAll([transferTxPromise, multiTransferTxPromise, txsAllResultPromise], {memo: 'test'});
    console.log(txsAllResult2.tx);
    console.log(txsAllResult2.txHash);
    // execute messages
    await txsAllResult2.execute();
    
```