### PR TITLE
Fix/overwrite wallets

### DIFF
--- a/tools/kysor/src/commands/valaccounts.ts
+++ b/tools/kysor/src/commands/valaccounts.ts
@@ -91,7 +91,9 @@ valaccounts
         valaccount = await KyveSDK.generateMnemonic();
       }
       // check if name already exists
-      if(fs.existsSync(path.join(HOME, "valaccounts", `${options.name}.toml`))) {
+      if (
+        fs.existsSync(path.join(HOME, "valaccounts", `${options.name}.toml`))
+      ) {
         console.log(
           `ERROR: Already created a valaccount with name = ${options.name}`
         );

--- a/tools/kysor/src/commands/valaccounts.ts
+++ b/tools/kysor/src/commands/valaccounts.ts
@@ -90,7 +90,13 @@ valaccounts
       } else {
         valaccount = await KyveSDK.generateMnemonic();
       }
-
+      // check if name already exists
+      if(fs.existsSync(path.join(HOME, "valaccounts", `${options.name}.toml`))) {
+        console.log(
+          `ERROR: Already created a valaccount with name = ${options.name}`
+        );
+        return;
+      }
       // check if same valaccount was already created
       const configs = fs.readdirSync(path.join(HOME, "valaccounts"));
       const valaccounts = [];

--- a/tools/kysor/src/kysor.ts
+++ b/tools/kysor/src/kysor.ts
@@ -1,11 +1,11 @@
 import TOML from "@iarna/toml";
 import KyveSDK from "@kyvejs/sdk";
 import { PoolResponse } from "@kyvejs/types/lcd/kyve/query/v1beta1/pools";
+import dotenv from "dotenv";
 import download from "download";
 import extract from "extract-zip";
 import fs from "fs";
 import path from "path";
-import dotenv from "dotenv";
 
 import { IConfig, IValaccountConfig } from "./types/interfaces";
 import { getChecksum, setupLogger, startNodeProcess } from "./utils";


### PR DESCRIPTION
If two commands are entered twice, the wallet will be overwritten and replaced by a new one without any warning message.
This fix disallows the user to create a wallet with the name of the wallet that already exists.   
```
./kysor valaccounts create \
--name 'moonbeam' \
--pool 0 \
--storage-priv "$(cat path/to/arweave.json)" \
--metrics
```