### PR TITLE
fix: remove duplicate Content-Type tag

### DIFF
--- a/common/protocol/src/reactors/storageProviders/Bundlr.ts
+++ b/common/protocol/src/reactors/storageProviders/Bundlr.ts
@@ -41,19 +41,9 @@ export class Bundlr implements IStorageProvider {
   }
 
   async saveBundle(bundle: Buffer, tags: BundleTag[]) {
-    const transactionOptions = {
-      tags: [
-        {
-          name: "Content-Type",
-          value: "text/plain",
-        },
-        ...tags,
-      ],
-    };
-
     const transaction = this.bundlrClient.createTransaction(
       bundle,
-      transactionOptions
+      { tags }
     );
 
     await transaction.sign();


### PR DESCRIPTION
The `createBundleProposal` method is in charge of setting the appropriate Content-Type of the Bundle already.

This change avoids setting two conflicting types on a single bundle, [like this](https://viewblock.io/arweave/tx/9uLR4Pp4F3kkH3LpebSYSmMz9z65BAXGJnIwAronq1M).