### PR TITLE
fix: runtime check

### DIFF
--- a/common/protocol/src/index.ts
+++ b/common/protocol/src/index.ts
@@ -308,15 +308,6 @@ export class Validator {
     await this.setupSDK();
     await this.syncPoolState(true);
 
-    // perform validation checks
-    if (!this.isValidRuntime()) {
-      process.exit(1);
-    }
-
-    if (!this.isValidVersion()) {
-      process.exit(1);
-    }
-
     if (await this.isStorageBalanceZero()) {
       process.exit(1);
     }
@@ -324,10 +315,6 @@ export class Validator {
     // until data is not available we wait and idle
     while (!(await this.isDataAvailable())) {
       await sleep(IDLE_TIME);
-    }
-
-    if (!(await this.isDataAvailable())) {
-      process.exit(1);
     }
 
     await this.setupValidator();

--- a/common/protocol/src/methods/main/runNode.ts
+++ b/common/protocol/src/methods/main/runNode.ts
@@ -29,15 +29,6 @@ export async function runNode(this: Validator): Promise<void> {
     await this.syncPoolState();
     await this.getBalancesForMetrics();
 
-    // perform basic validation checks, if one fails exit
-    if (!this.isValidRuntime()) {
-      process.exit(1);
-    }
-
-    if (!this.isValidVersion()) {
-      process.exit(1);
-    }
-
     if (!this.isNodeValidator()) {
       process.exit(1);
     }

--- a/common/protocol/src/methods/queries/syncPoolState.ts
+++ b/common/protocol/src/methods/queries/syncPoolState.ts
@@ -32,8 +32,16 @@ export async function syncPoolState(
             id: this.poolId.toString(),
           });
           this.pool = pool!;
-
           this.m.query_pool_successful.inc();
+
+          // perform validation checks
+          if (!this.isValidRuntime()) {
+            process.exit(1);
+          }
+
+          if (!this.isValidVersion()) {
+            process.exit(1);
+          }
 
           // if config link has changed sync the config
           if (prevConfig !== this.pool.data!.config) {


### PR DESCRIPTION
The runtime method `validateSetConfig` was called before the runtime name and version where checked. This caued confusion among those who accidently had the wrong runtime running.