### PR TITLE
fix: replace bundlr with arweave endpoint

### DIFF
--- a/common/protocol/src/reactors/storageProviders/Bundlr.ts
+++ b/common/protocol/src/reactors/storageProviders/Bundlr.ts
@@ -26,7 +26,7 @@ export class Bundlr implements IStorageProvider {
 
   private get bundlrClient(): BundlrClient {
     return new BundlrClient(
-      "http://node1.bundlr.network",
+      "https://up.arweave.net",
       "arweave",
       this.bundlrKeyfile
     );

--- a/common/protocol/src/utils/constants.ts
+++ b/common/protocol/src/utils/constants.ts
@@ -10,7 +10,7 @@ export const REFRESH_TIME = 10 * 1000;
 export const ERROR_IDLE_TIME = 10 * 1000;
 
 // the max bundle size allowed to upload - currently 200MB
-export const MAX_BUNDLE_BYTE_SIZE = 200 * 1024 * 1024;
+export const MAX_BUNDLE_BYTE_SIZE = 100 * 1024 * 1024;
 
 // the max compression size - currently 2GB
 export const MAX_COMPRESSION_BYTE_SIZE = 2 * 10 ** 9;


### PR DESCRIPTION
Due to the planned removal of Irys (previously Bundlr) out of Arweave's optimistic cache (more on that [here](https://twitter.com/samecwilliams/status/1736506715523178571)) which would cause the stalling of all pools, the default endpoint is temporarily replaced with Arweave's [Turbo](https://ardrive.io/turbo/) solution.