### PR TITLE
Bundle Resubmission

### DIFF
--- a/common/protocol/src/index.ts
+++ b/common/protocol/src/index.ts
@@ -99,6 +99,13 @@ export class Validator {
   protected metricsPort!: number;
   protected home!: string;
 
+  // tmp variables
+  protected lastUploadedBundle: {
+    storageId: string;
+    dataSize: number;
+    dataHash: string;
+  } | null = null;
+
   // setups
   protected setupLogger = setupLogger;
   protected setupCacheProvider = setupCacheProvider;


### PR DESCRIPTION
Resubmit the bundles if the data matches with the bundle uploaded the last round. This saves significant storage fees if a pool is constantly dropping bundles