### PR TITLE
chore(types): avoid type errors from downstream esm NodeNext compiler

### DIFF
--- a/common/sdk/src/sdk.ts
+++ b/common/sdk/src/sdk.ts
@@ -191,7 +191,7 @@ export class KyveSDK {
       walletName
     );
     this.walletSupports.add(SUPPORTED_WALLETS.KEPLR);
-    return client;
+    return client as KyveWebClient;
   }
 
   /**

--- a/common/sdk/src/utils/cosmostation-helper.ts
+++ b/common/sdk/src/utils/cosmostation-helper.ts
@@ -83,7 +83,7 @@ export class CosmostationSigner implements OfflineDirectSigner {
     ];
   }
 
-  async signDirect(signerAddress: string, signDoc: SignDoc) {
+  async signDirect(_signerAddress: string, signDoc: SignDoc) {
     const signedResult = await cosmostationMethods.signDirect(
       this.config.chainId,
       {


### PR DESCRIPTION
hello! working on a turbo-sdk integration here in the esm `nodenext` environment with TypeScript `5.5.4` and I'm getting working through some compiler type issues to get the the libraries building together.  I'm mostly stuck on this `KyveClient` type being returned in the Keplr helper

```sh
node_modules/@kyvejs/sdk/src/sdk.ts:194:5 - error TS2739: Type 'KyveClient' is missing the following properties from type 'KyveWebClient': walletName, getWalletName

194     return client;
        ~~~~~~


Found 1 error in node_modules/@kyvejs/sdk/src/sdk.ts:194
```

in the IDE for kyveJS the type looks fine to me. but casting this type as web client resolves the compile time issue on our end. 

The other change with adding `_` on the unused parameter here is from our own tsconfig file more strict