### PR TITLE
chore: avoid downstream dependency runtime errors

### DIFF
--- a/common/sdk/package.json
+++ b/common/sdk/package.json
@@ -26,6 +26,7 @@
     "@cosmjs/amino": "^0.32.3",
     "@cosmjs/crypto": "^0.32.3",
     "@cosmjs/encoding": "^0.32.3",
+    "@cosmjs/math": "^0.32.4",
     "@cosmjs/proto-signing": "^0.32.3",
     "@cosmjs/stargate": "^0.32.3",
     "@cosmostation/extension-client": "^0.1.15",
@@ -34,6 +35,7 @@
     "axios": "^0.27.2",
     "bech32": "2.0.0",
     "bignumber.js": "9.1.2",
+    "cosmjs-types": "^0.9.0",
     "humanize-number": "0.0.2",
     "qs": "^6.10.5"
   },

--- a/common/types/package.json
+++ b/common/types/package.json
@@ -24,5 +24,9 @@
   "devDependencies": {
     "rimraf": "^3.0.2",
     "typescript": "^4.7.3"
+  },
+  "dependencies": {
+    "long": "^5.2.3",
+    "protobufjs": "^7.4.0"
   }
 }


### PR DESCRIPTION
hey there! we're running into some runtime errors when integrating @kyvejs/sdk into some of our software:

```sh
Error: @kyvejs/types tried to access long, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: long
Required by: @kyvejs/types@npm:1.4.0 (via /Users/derek/ar-io/ardrive-cli/.yarn/cache/@kyvejs-types-npm-1.4.0-fab6e0745a-fe33d33dc0.zip/node_modules/@kyvejs/types/client/cosmos/gov/v1/)

Require stack:
- /Users/derek/ar-io/ardrive-cli/.yarn/cache/@kyvejs-types-npm-1.4.0-fab6e0745a-fe33d33dc0.zip/node_modules/@kyvejs/types/client/cosmos/gov/v1/tx.js


Error: @kyvejs/sdk tried to access @cosmjs/math, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: @cosmjs/math
Required by: @kyvejs/sdk@npm:1.3.2 (via /Users/derek/ar-io/ardrive-cli/.yarn/cache/@kyvejs-sdk-npm-1.3.2-8e96208daf-38c4edce14.zip/node_modules/@kyvejs/sdk/dist/amino/)

Require stack:
- /Users/derek/ar-io/ardrive-cli/.yarn/cache/@kyvejs-sdk-npm-1.3.2-8e96208daf-38c4edce14.zip/node_modules/@kyvejs/sdk/dist/amino/stakers.amino.js
- /Users/derek/ar-io/ardrive-cli/.yarn/cache/@kyvejs-sdk-npm-1.3.2-8e96208daf-38c4edce14.zip/node_modules/@kyvejs/sdk/dist/amino/index.js
- /Users/derek/ar-io/ardrive-cli/.yarn/cache/@kyvejs-sdk-npm-1.3.2-8e96208daf-38c4edce14.zip/node_modules/@kyvejs/sdk/dist/clients/full-client.js

            ^

Error: @kyvejs/types tried to access protobufjs, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: protobufjs (via "protobufjs/minimal")
Required by: @kyvejs/types@npm:1.4.0 (via /Users/derek/ar-io/ardrive-cli/.yarn/cache/@kyvejs-types-npm-1.4.0-fab6e0745a-fe33d33dc0.zip/node_modules/@kyvejs/types/client/cosmos/gov/v1/)

Require stack:
- /Users/derek/ar-io/ardrive-cli/.yarn/cache/@kyvejs-types-npm-1.4.0-fab6e0745a-fe33d33dc0.zip/node_modules/@kyvejs/types/client/cosmos/gov/v1/tx.js

          ^

Error: @kyvejs/sdk tried to access cosmjs-types, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: cosmjs-types (via "cosmjs-types/cosmos/tx/v1beta1/tx")
Required by: @kyvejs/sdk@npm:1.3.2 (via /Users/derek/ar-io/ardrive-cli/.yarn/cache/@kyvejs-sdk-npm-1.3.2-8e96208daf-38c4edce14.zip/node_modules/@kyvejs/sdk/dist/clients/rpc-client/)

Require stack:
- /Users/derek/ar-io/ardrive-cli/.yarn/cache/@kyvejs-sdk-npm-1.3.2-8e96208daf-38c4edce14.zip/node_modules/@kyvejs/sdk/dist/clients/rpc-client/signing.js
```

providing these dependencies in the PR does avoid these errors, but it will be better to have KYVE SDK providing them