### PR TITLE
fix: allow `null` for `finalize_block_events`

### DIFF
--- a/integrations/tendermint/src/schemas/block_result.json
+++ b/integrations/tendermint/src/schemas/block_result.json
@@ -148,7 +148,7 @@
       ]
     },
     "finalize_block_events": {
-      "type": ["array"],
+      "type": ["array", "null"],
       "items": [
         {
           "type": "object",


### PR DESCRIPTION
This PR updates the Tendermint `block_results` schema allowing the `finalize_block_events` to be `null` due to issues on the [Osmosis Mainnet pool](https://app.kyve.network/#/pools/1).