### PR TITLE
feat: enable the interval to be updated

### DIFF
--- a/integrations/tendermint-ssync/src/runtime.ts
+++ b/integrations/tendermint-ssync/src/runtime.ts
@@ -201,6 +201,15 @@ export default class TendermintSSync implements IRuntime {
     // move on to next snapshot and start at first chunk
     // if we have already reached all chunks in current snapshot
     if (snapshot.chunks - 1 === chunkIndex) {
+      // since the interval can change and the cosmos apps always create
+      // snapshots if the block height is divisible by the interval we
+      // search for the next height which fits this definition
+      for (let h = height + 1; h <= height + this.config.interval; h++) {
+        if (h % this.config.interval === 0) {
+          return `${h}/0`;
+        }
+      }
+
       return `${height + this.config.interval}/0`;
     }
 

--- a/integrations/tendermint-ssync/src/runtime.ts
+++ b/integrations/tendermint-ssync/src/runtime.ts
@@ -201,9 +201,9 @@ export default class TendermintSSync implements IRuntime {
     // move on to next snapshot and start at first chunk
     // if we have already reached all chunks in current snapshot
     if (snapshot.chunks - 1 === chunkIndex) {
-      // since the interval can change and the cosmos apps always create
-      // snapshots if the block height is divisible by the interval we
-      // search for the next height which fits this definition
+      // since the interval can change and the cosmos apps always creates
+      // snapshots if the block height is divisible by the interval (without remainder)
+      //  we search for the next height which fits this definition
       for (let h = height + 1; h <= height + this.config.interval; h++) {
         if (h % this.config.interval === 0) {
           return `${h}/0`;


### PR DESCRIPTION
This PR makes the snapshot interval updatable. It is important that this is a major release to ensure all protocol validators have this version, since it is a breaking change in case of an interval updating, possibly leading to invalid votes.

Context: The cosmos app always creates snapshots at a certain interval when the block height is divisible without remainder by the interval, to account for that when the interval changes we always search for the next block height in `nextKey` which fits this definition.