### PR TITLE
chore: add new scale factor for no loss

### DIFF
--- a/common/protocol/src/index.ts
+++ b/common/protocol/src/index.ts
@@ -104,6 +104,7 @@ export class Validator {
   protected dryRun!: boolean;
   protected dryRunBundles!: number;
   protected ensureNoLoss!: boolean;
+  protected scaleEnsureNoLoss!: number;
   protected params!: QueryParamsResponse;
 
   // tmp variables
@@ -305,6 +306,11 @@ export class Validator {
         "Ensures that the node only uploads bundles which can be fully rewarded by the protocol.",
         true
       )
+      .option(
+        "--scale-ensure-no-loss <number>",
+        "Scales the maximum bytes which ensure no loss with this scale factor. E.g 0.5 would mean that you would only upload 50% of the bundle size that what you could normally upload with no loss, 0 to disable this.",
+        "0"
+      )
       .action((options) => {
         this.start(options);
       });
@@ -345,6 +351,7 @@ export class Validator {
     this.dryRun = options.dryRun;
     this.dryRunBundles = parseInt(options.dryRunBundles);
     this.ensureNoLoss = options.ensureNoLoss;
+    this.scaleEnsureNoLoss = options.scaleEnsureNoLoss;
 
     if (!this.poolAccount) {
       this.logger.fatal(`Pool account not found. Exiting ...`);

--- a/common/protocol/src/methods/upload/createBundleProposal.ts
+++ b/common/protocol/src/methods/upload/createBundleProposal.ts
@@ -152,6 +152,10 @@ export async function createBundleProposal(this: Validator): Promise<void> {
       }
     }
 
+    if (this.scaleEnsureNoLoss > 0) {
+      maxBytes *= this.scaleEnsureNoLoss;
+    }
+
     let low = 0;
     let high = bundleProposal.length - 1;
     let maxIndex = -1;

--- a/tools/kysor/src/commands/start.ts
+++ b/tools/kysor/src/commands/start.ts
@@ -28,6 +28,16 @@ start
     "--gas-price <number>",
     "The gas price the node should use to calculate transaction fees, this value will be loaded by default based on the chain id"
   )
+  .option(
+    "--ensure-no-loss",
+    "Ensures that the node only uploads bundles which can be fully rewarded by the protocol.",
+    true
+  )
+  .option(
+    "--scale-ensure-no-loss <number>",
+    "Scales the maximum bytes which ensure no loss with this scale factor. E.g 0.5 would mean that you would only upload 50% of the bundle size that what you could normally upload with no loss, 0 to disable this.",
+    "0"
+  )
   .action(async (options) => {
     await run(options);
   });

--- a/tools/kysor/src/kysor.ts
+++ b/tools/kysor/src/kysor.ts
@@ -404,6 +404,15 @@ export const run = async (options: any) => {
         `${versionHome}`,
       ];
 
+      if (options.ensureNoLoss) {
+        args.push("--ensure-no-loss");
+        args.push(`--scale-ensure-no-loss`);
+        args.push(`${options.scaleEnsureNoLoss}`);
+      } else {
+        args.push("--ensure-no-loss");
+        args.push(`${false}`);
+      }
+
       if (options.debug) {
         args.push("--debug");
       }


### PR DESCRIPTION
Included a custom scale factor so protocol node operators can more freely tweak the ensure no loss settings so that they actually have no losses due to outdated storage costs.